### PR TITLE
ADD: interval mode to service call and determine message to be included

### DIFF
--- a/rosbag2_snapshot/CMakeLists.txt
+++ b/rosbag2_snapshot/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(rosbag2_snapshot_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 include_directories(
   include
@@ -39,6 +40,7 @@ set(DEPENDENCIES
   sensor_msgs
   OpenCV
   cv_bridge
+  visualization_msgs
 )
 
 set(executable_name snapshotter)

--- a/rosbag2_snapshot/CMakeLists.txt
+++ b/rosbag2_snapshot/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(rosbag2_snapshot_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(cv_bridge REQUIRED)
-find_package(visualization_msgs REQUIRED)
 
 include_directories(
   include
@@ -40,7 +39,6 @@ set(DEPENDENCIES
   sensor_msgs
   OpenCV
   cv_bridge
-  visualization_msgs
 )
 
 set(executable_name snapshotter)

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -38,6 +38,8 @@
 #include <rosbag2_compression/sequential_compression_writer.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <visualization_msgs/msg/image_marker.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -315,6 +317,14 @@ private:
   void resume();
   // Poll master for new topics
   void pollTopics();
+  // Check if a message is inside the time interval defined by req
+  template<typename MsgType>
+  bool isMsgInsideInterval(
+      const MsgType& msg,
+      const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
+      MessageQueue::queue_t::const_iterator msg_it,
+      const TopicDetails& topic_details
+  );
   // Write the parts of message_queue within the time constraints of req to the queue
   // If returns false, there was an error opening/writing the bag and an error message
   // was written to res.message

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -39,6 +39,7 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <visualization_msgs/msg/image_marker.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -314,6 +315,14 @@ private:
   void resume();
   // Poll master for new topics
   void pollTopics();
+  // Check if a message is inside the time interval defined by req
+  template<typename MsgType>
+  bool isMsgInsideInterval(
+      const MsgType& msg,
+      const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
+      MessageQueue::queue_t::const_iterator msg_it,
+      const TopicDetails& topic_details
+  );
   // Write the parts of message_queue within the time constraints of req to the queue
   // If returns false, there was an error opening/writing the bag and an error message
   // was written to res.message

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -226,7 +226,7 @@ public:
   typedef std::pair<queue_t::const_iterator, queue_t::const_iterator> range_t;
   // Get a begin and end iterator into the buffer respecting the start and
   // end timestamp constraints
-  range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end, const rclcpp::Time & msg_timestamp);
+  range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end);
 
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const & msg) const;

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -229,6 +229,8 @@ public:
   // Get a begin and end iterator into the buffer respecting the start and
   // end timestamp constraints
   range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end);
+  // Get a begin and end iterator into the buffer around the msg_timestamp and tolerance
+  range_t intervalFromTimesMsg(const rclcpp::Time & msg_timestamp, const double & tolerance);
 
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const & msg) const;

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -38,6 +38,7 @@
 #include <rosbag2_compression/sequential_compression_writer.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgcodecs.hpp>

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -317,12 +317,11 @@ private:
   void resume();
   // Poll master for new topics
   void pollTopics();
-  // Check if a message is inside the time interval defined by req
+  // Check if a message is the specific we are looking for compared to the timestamp
   template<typename MsgType>
-  bool isMsgInsideInterval(
+  bool isTheSpecificMsg(
       const MsgType& msg,
       const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
-      MessageQueue::queue_t::const_iterator msg_it,
       const TopicDetails& topic_details
   );
   // Write the parts of message_queue within the time constraints of req to the queue

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -38,8 +38,6 @@
 #include <rosbag2_compression/sequential_compression_writer.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
-#include <sensor_msgs/msg/camera_info.hpp>
-#include <visualization_msgs/msg/image_marker.hpp>
 #include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -317,14 +315,6 @@ private:
   void resume();
   // Poll master for new topics
   void pollTopics();
-  // Check if a message is inside the time interval defined by req
-  template<typename MsgType>
-  bool isMsgInsideInterval(
-      const MsgType& msg,
-      const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
-      MessageQueue::queue_t::const_iterator msg_it,
-      const TopicDetails& topic_details
-  );
   // Write the parts of message_queue within the time constraints of req to the queue
   // If returns false, there was an error opening/writing the bag and an error message
   // was written to res.message

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -227,6 +227,9 @@ public:
   // Get a begin and end iterator into the buffer respecting the start and
   // end timestamp constraints
   range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end);
+  // Get a begin and end iterator into the buffer respecting the start and
+  // end timestamp constraints around the message timestamp
+  range_t intervalFromTimes(const rclcpp::Time & start, const rclcpp::Time & end, const rclcpp::Time & msg_timestamp);
 
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const & msg) const;

--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -226,10 +226,7 @@ public:
   typedef std::pair<queue_t::const_iterator, queue_t::const_iterator> range_t;
   // Get a begin and end iterator into the buffer respecting the start and
   // end timestamp constraints
-  range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end);
-  // Get a begin and end iterator into the buffer respecting the start and
-  // end timestamp constraints around the message timestamp
-  range_t intervalFromTimes(const rclcpp::Time & start, const rclcpp::Time & end, const rclcpp::Time & msg_timestamp);
+  range_t rangeFromTimes(const rclcpp::Time & start, const rclcpp::Time & end, const rclcpp::Time & msg_timestamp);
 
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const & msg) const;

--- a/rosbag2_snapshot/package.xml
+++ b/rosbag2_snapshot/package.xml
@@ -21,7 +21,6 @@
   <depend>sensor_msgs</depend>
   <depend>OpenCV</depend>
   <depend>cv_bridge</depend>
-  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_snapshot/package.xml
+++ b/rosbag2_snapshot/package.xml
@@ -21,6 +21,7 @@
   <depend>sensor_msgs</depend>
   <depend>OpenCV</depend>
   <depend>cv_bridge</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -241,16 +241,10 @@ SnapshotMessage MessageQueue::_pop()
   return tmp;
 }
 
-MessageQueue::range_t MessageQueue::rangeFromTimes(Time const & start, Time const & stop, Time const & msg_time)
+MessageQueue::range_t MessageQueue::rangeFromTimes(Time const & start, Time const & stop)
 {
   range_t::first_type begin = queue_.begin();
   range_t::second_type end = queue_.end();
-
-  // check that msg_time is within the range
-  if (msg_time < start || msg_time > stop) {
-    RCLCPP_ERROR(logger_, "msg_time is not within the range of start and stop times");
-    // We dont return as if we dont shorten the range the bag will be the size of the whole queue
-  }
   
   if(options_.duration_limit_ != options_.NO_DURATION_LIMIT)
   {
@@ -657,7 +651,7 @@ bool Snapshotter::writeTopic(
   // acquire lock for this queue
   std::lock_guard l(message_queue.lock);
 
-  MessageQueue::range_t range = message_queue.rangeFromTimes(req->start_time, req->stop_time, req->msg_timestamp);
+  MessageQueue::range_t range = message_queue.rangeFromTimes(req->start_time, req->stop_time);
 
   rosbag2_storage::TopicMetadata tm;
   tm.name = topic_details.name;
@@ -713,6 +707,22 @@ bool Snapshotter::writeTopic(
       sensor_msgs::msg::Image raw_img;
       sensor_msgs::msg::CompressedImage compressed_img;
       img_serializer.deserialize_message(msg_it->msg.get(), &raw_img);
+      // if use_interval_mode is true, and msg has header
+      if (req->use_interval_mode)
+      {
+          double nsec_diff = raw_img.header.stamp.nanosec - req->msg_timestamp.nanosec;
+          double diff_sec = std::abs(raw_img.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff / 1e9);
+
+          // Check if the message is within the tolerance
+          if (diff_sec < req->interval_mode_tolerance)
+          {
+              RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %d", topic_details.name.c_str(), raw_img.header.stamp.sec);
+          }
+          else
+          {
+              continue;
+          }
+      }
       // imencode expects rgb images in `bgr` encoding, so we need to change incoming images that
       // use `rbg8` encoding to `bgr8` encoding by hand.
       if (raw_img.encoding == "rgb8")

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -682,7 +682,7 @@ bool Snapshotter::writeTopic(
       return false;
     }
       
-    if (topic_details.throttle_period > 0.0 && msg_it->time.nanoseconds() - prev_msg_time <= topic_details.throttle_period * 1e9)
+    if (!req->use_interval_mode && topic_details.throttle_period > 0.0 && msg_it->time.nanoseconds() - prev_msg_time <= topic_details.throttle_period * 1e9)
     {
       RCLCPP_DEBUG(get_logger(), "topic %s is being throttled. message time: %ld, previous message time: %f, throttle_period: %f", topic_details.name.c_str(), msg_it->time.nanoseconds(), prev_msg_time, topic_details.throttle_period);
       continue;
@@ -711,10 +711,10 @@ bool Snapshotter::writeTopic(
       if (req->use_interval_mode)
       {
           double nsec_diff = raw_img.header.stamp.nanosec - req->msg_timestamp.nanosec;
-          double diff_sec = std::abs(raw_img.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff / 1e9);
+          double diff_sec = std::abs(raw_img.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff * 1e-9);
 
           // Check if the message is within the tolerance
-          if (diff_sec < req->interval_mode_tolerance)
+          if (diff_sec <= req->interval_mode_tolerance)
           {
               RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %d", topic_details.name.c_str(), raw_img.header.stamp.sec);
           }

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -747,13 +747,7 @@ bool Snapshotter::writeTopic(
       cam_info_serializer.deserialize_message(msg_it->msg.get(), &cam_info);
 
       if (!isTheSpecificMsg<sensor_msgs::msg::CameraInfo>(cam_info, req, topic_details))
-      {
         continue;
-      }
-      else
-      {
-        break;
-      }
     }
 
     if (tm.type == "visualization_msgs/msg/ImageMarker" && req->use_interval_mode && req->interval_mode_single_msg)
@@ -763,8 +757,6 @@ bool Snapshotter::writeTopic(
 
       if(!isTheSpecificMsg<visualization_msgs::msg::ImageMarker>(img_marker, req, topic_details))
         continue;
-      else 
-        break;
     }
 
     if(topic_details.img_compression_opts_.use_compression)
@@ -777,8 +769,6 @@ bool Snapshotter::writeTopic(
       {
         if (!isTheSpecificMsg<sensor_msgs::msg::Image>(raw_img, req, topic_details))
           continue;
-        else
-          break;
       }
       // imencode expects rgb images in `bgr` encoding, so we need to change incoming images that
       // use `rbg8` encoding to `bgr8` encoding by hand.
@@ -816,9 +806,6 @@ bool Snapshotter::isTheSpecificMsg(
   const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
   const TopicDetails& topic_details) 
 {
-  RCLCPP_INFO(get_logger(), "Checking message for topic %s", topic_details.name.c_str());
-  RCLCPP_INFO(get_logger(), "msg sec: %d, msg nanosec: %d", msg.header.stamp.sec, msg.header.stamp.nanosec);
-  RCLCPP_INFO(get_logger(), "req sec: %d, req nanosec: %d", req->msg_timestamp.sec, req->msg_timestamp.nanosec);
   if (msg.header.stamp != req->msg_timestamp) return false;
 
   RCLCPP_WARN(get_logger(), "[INTERVAL_MODE]: Found message for topic %s", topic_details.name.c_str());

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -689,10 +689,6 @@ bool Snapshotter::writeTopic(
   tm.serialization_format = "cdr";
 
   rclcpp::Serialization<sensor_msgs::msg::Image> img_serializer;
-  rclcpp::Serialization<sensor_msgs::msg::CameraInfo> cam_info_serializer;
-  cam_info_serializer = rclcpp::Serialization<sensor_msgs::msg::CameraInfo>();
-  rclcpp::Serialization<visualization_msgs::msg::ImageMarker> img_marker_serializer;
-  img_marker_serializer = rclcpp::Serialization<visualization_msgs::msg::ImageMarker>();
   cv_bridge::CvImagePtr cv_bridge_img;
   std::vector<int> compression_params; 
   if(topic_details.img_compression_opts_.use_compression)
@@ -740,30 +736,11 @@ bool Snapshotter::writeTopic(
       bag_message->time_stamp = msg_it->time.nanoseconds();
     }
 
-    if (tm.type == "sensor_msgs/msg/CameraInfo" && req->use_interval_mode)
-    {
-      sensor_msgs::msg::CameraInfo cam_info;
-      cam_info_serializer.deserialize_message(msg_it->msg.get(), &cam_info);
-
-      if (!isMsgInsideInterval<sensor_msgs::msg::CameraInfo>(cam_info, req, msg_it, topic_details)) continue;
-    }
-
-    if (tm.type == "visualization_msgs/msg/ImageMarker" && req->use_interval_mode)
-    {
-      visualization_msgs::msg::ImageMarker img_marker;
-      img_marker_serializer.deserialize_message(msg_it->msg.get(), &img_marker);
-
-      if(!isMsgInsideInterval<visualization_msgs::msg::ImageMarker>(img_marker, req, msg_it, topic_details)) continue;
-    }
-
     if(topic_details.img_compression_opts_.use_compression)
     {
       sensor_msgs::msg::Image raw_img;
       sensor_msgs::msg::CompressedImage compressed_img;
       img_serializer.deserialize_message(msg_it->msg.get(), &raw_img);
-
-      if (req->use_interval_mode && !isMsgInsideInterval<sensor_msgs::msg::Image>(raw_img, req, msg_it, topic_details))
-        continue;
       
       // imencode expects rgb images in `bgr` encoding, so we need to change incoming images that
       // use `rbg8` encoding to `bgr8` encoding by hand.
@@ -792,26 +769,6 @@ bool Snapshotter::writeTopic(
     }
   }
 
-  return true;
-}
-
-template<typename MsgType>
-bool Snapshotter::isMsgInsideInterval(
-  const MsgType& msg,
-  const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req, // The request object, assuming a common type here
-  MessageQueue::queue_t::const_iterator msg_it, // Iterator to the current message, assuming a common type
-  const TopicDetails& topic_details) 
-{
-  // Calculate time difference
-  double nsec_diff = msg.header.stamp.nanosec - req->msg_timestamp.nanosec;
-  double diff_sec = std::abs((msg.header.stamp.sec - req->msg_timestamp.sec) + (nsec_diff * 1e-9));
-
-  // Check if the message is within the tolerance
-  if (diff_sec > req->interval_mode_tolerance) return false;
-
-  // Log message if within tolerance
-  RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %f",
-              topic_details.name.c_str(), msg_it->time.seconds());
   return true;
 }
 

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -774,7 +774,7 @@ bool Snapshotter::isMsgInsideInterval(
 {
   // Calculate time difference
   double nsec_diff = msg.header.stamp.nanosec - req->msg_timestamp.nanosec;
-  double diff_sec = std::abs(msg.header.stamp.sec - req->msg_timestamp.sec + nsec_diff * 1e-9);
+  double diff_sec = std::abs((msg.header.stamp.sec - req->msg_timestamp.sec) + (nsec_diff * 1e-9));
 
   // Check if the message is within the tolerance
   if (diff_sec > req->interval_mode_tolerance) return false;

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -249,6 +249,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const & start, Time cons
   // check that msg_time is within the range
   if (msg_time < start || msg_time > stop) {
     RCLCPP_ERROR(logger_, "msg_time is not within the range of start and stop times");
+    // We dont return as if we dont shorten the range the bag will be the size of the whole queue
   }
   
   if(options_.duration_limit_ != options_.NO_DURATION_LIMIT)

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -741,7 +741,7 @@ bool Snapshotter::writeTopic(
       bag_message->time_stamp = msg_it->time.nanoseconds();
     }
 
-    if (tm.type == "sensor_msgs/msg/CameraInfo" && req->use_interval_mode)
+    if (tm.type == "sensor_msgs/msg/CameraInfo" && req->use_interval_mode && req->interval_mode_single_msg)
     {
       sensor_msgs::msg::CameraInfo cam_info;
       cam_info_serializer.deserialize_message(msg_it->msg.get(), &cam_info);
@@ -756,7 +756,7 @@ bool Snapshotter::writeTopic(
       }
     }
 
-    if (tm.type == "visualization_msgs/msg/ImageMarker" && req->use_interval_mode)
+    if (tm.type == "visualization_msgs/msg/ImageMarker" && req->use_interval_mode && req->interval_mode_single_msg)
     {
       visualization_msgs::msg::ImageMarker img_marker;
       img_marker_serializer.deserialize_message(msg_it->msg.get(), &img_marker);
@@ -773,7 +773,7 @@ bool Snapshotter::writeTopic(
       sensor_msgs::msg::CompressedImage compressed_img;
       img_serializer.deserialize_message(msg_it->msg.get(), &raw_img);
 
-      if (req->use_interval_mode)
+      if (req->use_interval_mode && req->interval_mode_single_msg)
       {
         if (!isTheSpecificMsg<sensor_msgs::msg::Image>(raw_img, req, topic_details))
           continue;

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -816,6 +816,9 @@ bool Snapshotter::isTheSpecificMsg(
   const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req,
   const TopicDetails& topic_details) 
 {
+  RCLCPP_INFO(get_logger(), "Checking message for topic %s", topic_details.name.c_str());
+  RCLCPP_INFO(get_logger(), "msg sec: %d, msg nanosec: %d", msg.header.stamp.sec, msg.header.stamp.nanosec);
+  RCLCPP_INFO(get_logger(), "req sec: %d, req nanosec: %d", req->msg_timestamp.sec, req->msg_timestamp.nanosec);
   if (msg.header.stamp != req->msg_timestamp) return false;
 
   RCLCPP_WARN(get_logger(), "[INTERVAL_MODE]: Found message for topic %s", topic_details.name.c_str());

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -686,9 +686,12 @@ bool Snapshotter::writeTopic(
       return false;
     }
       
-    if (!req->use_interval_mode && topic_details.throttle_period > 0.0 && msg_it->time.nanoseconds() - prev_msg_time <= topic_details.throttle_period * 1e9)
+    if (!req->use_interval_mode && req->throttle_msgs && topic_details.throttle_period > 0.0 && msg_it->time.nanoseconds() - prev_msg_time <= topic_details.throttle_period * 1e9)
     {
-      RCLCPP_DEBUG(get_logger(), "topic %s is being throttled. message time: %ld, previous message time: %f, throttle_period: %f", topic_details.name.c_str(), msg_it->time.nanoseconds(), prev_msg_time, topic_details.throttle_period);
+      RCLCPP_DEBUG(get_logger(), 
+          "topic %s is being throttled. message time: %ld, previous message time: %f, throttle_period: %f", 
+          topic_details.name.c_str(), msg_it->time.nanoseconds(), prev_msg_time, topic_details.throttle_period
+      );
       continue;
     }
 

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -660,6 +660,9 @@ bool Snapshotter::writeTopic(
 
   rclcpp::Serialization<sensor_msgs::msg::Image> img_serializer;
   rclcpp::Serialization<sensor_msgs::msg::CameraInfo> cam_info_serializer;
+  cam_info_serializer = rclcpp::Serialization<sensor_msgs::msg::CameraInfo>();
+  rclcpp::Serialization<visualization_msgs::msg::ImageMarker> img_marker_serializer;
+  img_marker_serializer = rclcpp::Serialization<visualization_msgs::msg::ImageMarker>();
   cv_bridge::CvImagePtr cv_bridge_img;
   std::vector<int> compression_params; 
   if(topic_details.img_compression_opts_.use_compression)
@@ -705,37 +708,29 @@ bool Snapshotter::writeTopic(
 
     if (tm.type == "sensor_msgs/msg/CameraInfo" && req->use_interval_mode)
     {
-      cam_info_serializer = rclcpp::Serialization<sensor_msgs::msg::CameraInfo>();
       sensor_msgs::msg::CameraInfo cam_info;
       cam_info_serializer.deserialize_message(msg_it->msg.get(), &cam_info);
-      // if use_interval_mode is true, compare the message timestamp with the requested timestamp
-      // to only write messages within the tolerance
-      double nsec_diff = cam_info.header.stamp.nanosec - req->msg_timestamp.nanosec;
-      double diff_sec = std::abs(cam_info.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff * 1e-9);
 
-      // Check if the message is within the tolerance
-      if (diff_sec > req->interval_mode_tolerance) continue;
-      if (req->use_interval_mode) RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %f", topic_details.name.c_str(), msg_it->time.seconds());
+      if (!isMsgInsideInterval<sensor_msgs::msg::CameraInfo>(cam_info, req, msg_it, topic_details)) continue;
     }
 
-    
+    if (tm.type == "visualization_msgs/msg/ImageMarker" && req->use_interval_mode)
+    {
+      visualization_msgs::msg::ImageMarker img_marker;
+      img_marker_serializer.deserialize_message(msg_it->msg.get(), &img_marker);
+
+      if(!isMsgInsideInterval<visualization_msgs::msg::ImageMarker>(img_marker, req, msg_it, topic_details)) continue;
+    }
+
     if(topic_details.img_compression_opts_.use_compression)
     {
       sensor_msgs::msg::Image raw_img;
       sensor_msgs::msg::CompressedImage compressed_img;
       img_serializer.deserialize_message(msg_it->msg.get(), &raw_img);
 
-      // if use_interval_mode is true, compare the message timestamp with the requested timestamp
-      // to only write messages within the tolerance
-      if (req->use_interval_mode)
-      {
-          double nsec_diff = raw_img.header.stamp.nanosec - req->msg_timestamp.nanosec;
-          double diff_sec = std::abs(raw_img.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff * 1e-9);
-
-          // Check if the message is within the tolerance
-          if (diff_sec > req->interval_mode_tolerance) continue;
-          if (req->use_interval_mode) RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %f", topic_details.name.c_str(), msg_it->time.seconds());
-      }
+      if (req->use_interval_mode && !isMsgInsideInterval<sensor_msgs::msg::Image>(raw_img, req, msg_it, topic_details))
+        continue;
+      
       // imencode expects rgb images in `bgr` encoding, so we need to change incoming images that
       // use `rbg8` encoding to `bgr8` encoding by hand.
       if (raw_img.encoding == "rgb8")
@@ -763,6 +758,26 @@ bool Snapshotter::writeTopic(
     }
   }
 
+  return true;
+}
+
+template<typename MsgType>
+bool Snapshotter::isMsgInsideInterval(
+  const MsgType& msg,
+  const rosbag2_snapshot_msgs::srv::TriggerSnapshot::Request::SharedPtr& req, // The request object, assuming a common type here
+  MessageQueue::queue_t::const_iterator msg_it, // Iterator to the current message, assuming a common type
+  const TopicDetails& topic_details) 
+{
+  // Calculate time difference
+  double nsec_diff = msg.header.stamp.nanosec - req->msg_timestamp.nanosec;
+  double diff_sec = std::abs(msg.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff * 1e-9);
+
+  // Check if the message is within the tolerance
+  if (diff_sec > req->interval_mode_tolerance) return false;
+
+  // Log message if within tolerance
+  RCLCPP_INFO(get_logger(), "[INTERVAL_MODE]: Found message for topic %s with timestamp %f",
+              topic_details.name.c_str(), msg_it->time.seconds());
   return true;
 }
 

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -245,6 +245,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const & start, Time cons
 {
   range_t::first_type begin = queue_.begin();
   range_t::second_type end = queue_.end();
+
   
   if(options_.duration_limit_ != options_.NO_DURATION_LIMIT)
   {
@@ -741,7 +742,6 @@ bool Snapshotter::writeTopic(
       sensor_msgs::msg::Image raw_img;
       sensor_msgs::msg::CompressedImage compressed_img;
       img_serializer.deserialize_message(msg_it->msg.get(), &raw_img);
-      
       // imencode expects rgb images in `bgr` encoding, so we need to change incoming images that
       // use `rbg8` encoding to `bgr8` encoding by hand.
       if (raw_img.encoding == "rgb8")
@@ -874,6 +874,7 @@ void Snapshotter::triggerSnapshotCb(
       {
         RCLCPP_WARN(get_logger(), "Queue size for topic %s is %ld", topic.name.c_str(), message_queue.size_);
       }
+
       if (!writeTopic(*bag_writer_ptr, message_queue, details, req, res, request_time)) {
         res->success = false;
         res->message = "Failed to write topic " + topic.type + " to bag file.";

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -264,6 +264,27 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const & start, Time cons
   return range_t(begin, end);
 }
 
+MessageQueue::range_t MessageQueue::intervalFromTimes(Time const & start, Time const & stop, Time const & msg_time)
+{
+  range_t::first_type begin = queue_.begin();
+  range_t::second_type end = queue_.end();
+
+  if(options_.duration_limit_ == options_.NO_DURATION_LIMIT) return range_t(begin, end);
+  
+  // Increment / Decrement iterators until time contraints are met arounf msg_time
+  if (start.seconds() != 0.0 || start.nanoseconds() != 0) {
+    while (begin != end && (*begin).time < msg_time) {
+      ++begin;
+    }
+  }
+  if (stop.seconds() != 0.0 || stop.nanoseconds() != 0) {
+    while (end != begin && (*(end - 1)).time > msg_time) {
+      --end;
+    }
+  }
+  return range_t(begin, end);
+}
+
 const int Snapshotter::QUEUE_SIZE = 10;
 
 Snapshotter::Snapshotter(const rclcpp::NodeOptions & options)
@@ -652,7 +673,11 @@ bool Snapshotter::writeTopic(
   // acquire lock for this queue
   std::lock_guard l(message_queue.lock);
 
-  MessageQueue::range_t range = message_queue.rangeFromTimes(req->start_time, req->stop_time);
+  MessageQueue::range_t range;
+  if (!req->use_interval_mode)
+    MessageQueue::range_t range = message_queue.rangeFromTimes(req->start_time, req->stop_time);
+  else
+    MessageQueue::range_t range = message_queue.intervalFromTimes(req->start_time, req->stop_time, req->msg_timestamp);
 
   rosbag2_storage::TopicMetadata tm;
   tm.name = topic_details.name;

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -774,7 +774,7 @@ bool Snapshotter::isMsgInsideInterval(
 {
   // Calculate time difference
   double nsec_diff = msg.header.stamp.nanosec - req->msg_timestamp.nanosec;
-  double diff_sec = std::abs(msg.header.stamp.sec - req->msg_timestamp.sec) + std::abs(nsec_diff * 1e-9);
+  double diff_sec = std::abs(msg.header.stamp.sec - req->msg_timestamp.sec + nsec_diff * 1e-9);
 
   // Check if the message is within the tolerance
   if (diff_sec > req->interval_mode_tolerance) return false;

--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -272,22 +272,7 @@ MessageQueue::range_t MessageQueue::intervalFromTimesMsg(Time const & msg_timest
   Time start = msg_timestamp - rclcpp::Duration::from_seconds(tolerance);
   Time stop = msg_timestamp + rclcpp::Duration::from_seconds(tolerance);
 
-  // print range
-  RCLCPP_INFO(logger_, "Interval mode: start time: %f, stop time: %f, msg time: %f, tolerance: %f", start.seconds(), stop.seconds(), msg_timestamp.seconds(), tolerance);
-
   // Check that msg_timestamp is within the range of the queue
-  if (queue_.size() > 0)
-  {
-    if (msg_timestamp > start || msg_timestamp < stop)
-    {
-      RCLCPP_WARN(logger_, "Message timestamp is outside the range of the queue.");
-    }
-  }
-  else
-  {
-    RCLCPP_ERROR(logger_, "Queue is empty.");
-  }
-  
   if(options_.duration_limit_ != options_.NO_DURATION_LIMIT)
   {
     // Increment / Decrement iterators until time contraints are met
@@ -657,7 +642,7 @@ void Snapshotter::topicCb(
   }
 
   // Pack message and metadata into SnapshotMessage holder
-  SnapshotMessage out(msg, now());
+  SnapshotMessage out(msg, this->now());
   queue->push(out);
 }
 
@@ -755,8 +740,6 @@ bool Snapshotter::writeTopic(
       bag_message->time_stamp = msg_it->time.nanoseconds();
     }
 
-    RCLCPP_WARN(get_logger(), "Use interval mode: %i", req->use_interval_mode);
-
     if (tm.type == "sensor_msgs/msg/CameraInfo" && req->use_interval_mode)
     {
       sensor_msgs::msg::CameraInfo cam_info;
@@ -822,10 +805,6 @@ bool Snapshotter::isMsgInsideInterval(
   // Calculate time difference
   double nsec_diff = msg.header.stamp.nanosec - req->msg_timestamp.nanosec;
   double diff_sec = std::abs((msg.header.stamp.sec - req->msg_timestamp.sec) + (nsec_diff * 1e-9));
-
-  // print time difference
-  RCLCPP_INFO(get_logger(), "Time difference: %f", diff_sec);
-  RCLCPP_WARN(get_logger(), "msg time secs: %d, msg time nsecs: %d, req time secs: %d, req time nsecs: %d", msg.header.stamp.sec, msg.header.stamp.nanosec, req->msg_timestamp.sec, req->msg_timestamp.nanosec);
 
   // Check if the message is within the tolerance
   if (diff_sec > req->interval_mode_tolerance) return false;
@@ -901,7 +880,7 @@ void Snapshotter::triggerSnapshotCb(
     return;
   }
 
-  rclcpp::Time request_time = now();
+  rclcpp::Time request_time = this->now();
 
   // Write each selected topic's queue to bag file
   if (req->topics.size() && req->topics.at(0).name.size()) {

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -9,6 +9,8 @@ builtin_interfaces/Time start_time   # Earliest timestamp for a message to be in
                                      # If time(0), start at the earliest message in each topic's buffer
 builtin_interfaces/Time stop_time    # Latest timestamp for a message to be included in written bag
                                      # If time(0), stop at the most recent message in each topic's buffer
+bool throttle_msgs                   # If true, use the parameter of the topic to set the period of the messages
+                                     # If false, include all messages in the time range
 bool use_interval_mode               # If true, start_time and stop_time are interpreted as an interval around msg_timestamp
                                      # If false, start_time and stop_time are interpreted as absolute times
 builtin_interfaces/Time  msg_timestamp  # Timestamp of the message that triggered the snapshot

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -13,6 +13,9 @@ bool use_interval_mode               # If true, start_time and stop_time are int
                                      # If false, start_time and stop_time are interpreted as absolute times
 builtin_interfaces/Time  msg_timestamp  # Timestamp of the message that triggered the snapshot
                                         # that must be included. Helps in the interval_mode to avoid missing the message
+float32 interval_mode_tolerance       # Tolerance in seconds for interval mode. If a message falls within the interval
+                                     # [msg_timestamp - interval_mode_tolerance, msg_timestamp + interval_mode_tolerance]
+                                     # it will be included in the snapshot
 
 ---
 

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -9,6 +9,10 @@ builtin_interfaces/Time start_time   # Earliest timestamp for a message to be in
                                      # If time(0), start at the earliest message in each topic's buffer
 builtin_interfaces/Time stop_time    # Latest timestamp for a message to be included in written bag
                                      # If time(0), stop at the most recent message in each topic's buffer
+bool use_interval_mode               # If true, start_time and stop_time are interpreted as an interval around msg_timestamp
+                                     # If false, start_time and stop_time are interpreted as absolute times
+builtin_interfaces/Time  msg_timestamp  # When using interval_mode, the timestamp of the message that triggered the snapshot
+                                        # that must be included in the snapshot
 
 ---
 

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -11,8 +11,8 @@ builtin_interfaces/Time stop_time    # Latest timestamp for a message to be incl
                                      # If time(0), stop at the most recent message in each topic's buffer
 bool use_interval_mode               # If true, start_time and stop_time are interpreted as an interval around msg_timestamp
                                      # If false, start_time and stop_time are interpreted as absolute times
-builtin_interfaces/Time  msg_timestamp  # When using interval_mode, the timestamp of the message that triggered the snapshot
-                                        # that must be included in the snapshot
+builtin_interfaces/Time  msg_timestamp  # Timestamp of the message that triggered the snapshot
+                                        # that must be included. Helps in the interval_mode to avoid missing the message
 
 ---
 

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -18,6 +18,8 @@ builtin_interfaces/Time  msg_timestamp  # Timestamp of the message that triggere
 float32 interval_mode_tolerance       # Tolerance in seconds for interval mode. If a message falls within the interval
                                      # [msg_timestamp - interval_mode_tolerance, msg_timestamp + interval_mode_tolerance]
                                      # it will be included in the snapshot
+bool interval_mode_single_msg        # If true, only the message with timestamp msg_timestamp will be included in the snapshot
+                                     # If false, all messages within the interval will be included         
 
 ---
 


### PR DESCRIPTION
In some scenarios, it is useful to make really short snapshots, as only one message is the one that interests.

- Add: `use_interval_mode` (bool) to the snapshot service to warn this is the mode to be used
- Add: `msg_timestamp` (builtin_interfaces/Time) to the snapshot service to know the timestamp of the message we are interested in saving. 
- Add: `isMsgInsideInterval` (function) to determine if a message is within the defined interval by the request. If it doesn't it skips it from the queue. This function is useful for the `interval_mode`